### PR TITLE
Remove backend server for simple Vue-only setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+TUYA_ACCESS_ID=your_access_id
+TUYA_ACCESS_SECRET=your_access_secret
+TUYA_DEVICE_ID=your_device_id
+TUYA_BASE_URL=https://openapi.tuyaeu.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+public/config.js

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # TommyToilet
-Checks whether my cat went to the toilet today
+
+Small Vue.js app that checks whether my cat Tommy used his Tuya smart toilet today. The UI calls the Tuya API directly from the browser.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your `TUYA_ACCESS_ID`, `TUYA_ACCESS_SECRET`, `TUYA_DEVICE_ID` and optional `TUYA_BASE_URL`.
+2. Build the `config.js` file which embeds your credentials:
+
+```bash
+npm install
+npm run build
+```
+
+3. Open `public/index.html` in your browser or serve the `public` directory with any static web server.
+
+**Note:** The Tuya credentials end up in `public/config.js` and are therefore visible in the browser.
+

--- a/build.js
+++ b/build.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+require('dotenv').config();
+
+const config = {
+  TUYA_ACCESS_ID: process.env.TUYA_ACCESS_ID || '',
+  TUYA_ACCESS_SECRET: process.env.TUYA_ACCESS_SECRET || '',
+  TUYA_DEVICE_ID: process.env.TUYA_DEVICE_ID || '',
+  TUYA_BASE_URL: process.env.TUYA_BASE_URL || 'https://openapi.tuyaeu.com'
+};
+
+let output = '';
+for (const [key, value] of Object.entries(config)) {
+  output += `window.${key} = ${JSON.stringify(value)};\n`;
+}
+
+fs.writeFileSync(path.join(__dirname, 'public', 'config.js'), output);
+console.log('Generated public/config.js');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "tommytoilet",
+  "version": "1.0.0",
+  "description": "Checks whether my cat went to the toilet today",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "node build.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "dotenv": "^16.3.1"
+  }
+}
+

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Tommy Toilet</title>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+  </style>
+</head>
+<body>
+  <div id="app">
+    <h1>Tommy Toilet</h1>
+    <p v-if="loading">Loading...</p>
+    <p v-else>
+      <strong>Status:</strong>
+      <span v-if="usedToday">Tommy has been on the toilet today.</span>
+      <span v-else>Tommy has not been on the toilet today.</span>
+    </p>
+    <p v-if="lastUsage">Last usage: {{ new Date(lastUsage).toLocaleString() }}</p>
+  </div>
+  <script src="config.js"></script>
+  <script>
+    const { createApp } = Vue;
+
+    function toHex(buffer) {
+      return Array.from(new Uint8Array(buffer))
+        .map(b => b.toString(16).padStart(2, '0'))
+        .join('')
+        .toUpperCase();
+    }
+
+    async function signString(str, secret) {
+      const enc = new TextEncoder();
+      const key = await crypto.subtle.importKey(
+        'raw',
+        enc.encode(secret),
+        { name: 'HMAC', hash: 'SHA-256' },
+        false,
+        ['sign']
+      );
+      const signature = await crypto.subtle.sign('HMAC', key, enc.encode(str));
+      return toHex(signature);
+    }
+
+    async function getToken() {
+      const t = Date.now().toString();
+      const sign = await signString(
+        window.TUYA_ACCESS_ID + t,
+        window.TUYA_ACCESS_SECRET
+      );
+      const headers = {
+        'client_id': window.TUYA_ACCESS_ID,
+        'sign': sign,
+        't': t,
+        'sign_method': 'HMAC-SHA256'
+      };
+      const url = `${window.TUYA_BASE_URL}/v1.0/token?grant_type=1`;
+      const res = await fetch(url, { headers });
+      const data = await res.json();
+      return data.result.access_token;
+    }
+
+    async function fetchLastUsage() {
+      const token = await getToken();
+      const t = Date.now().toString();
+      const sign = await signString(
+        window.TUYA_ACCESS_ID + token + t,
+        window.TUYA_ACCESS_SECRET
+      );
+      const headers = {
+        'client_id': window.TUYA_ACCESS_ID,
+        'access_token': token,
+        'sign': sign,
+        't': t,
+        'sign_method': 'HMAC-SHA256'
+      };
+      const url = `${window.TUYA_BASE_URL}/v1.0/devices/${window.TUYA_DEVICE_ID}/logs`;
+      const res = await fetch(url, { headers });
+      const data = await res.json();
+      const logs = data.result && data.result.logs ? data.result.logs : [];
+      return logs.length ? logs[0].event_time : null;
+    }
+
+    createApp({
+      data() {
+        return { loading: true, usedToday: false, lastUsage: null };
+      },
+      async created() {
+        try {
+          const lastUsage = await fetchLastUsage();
+          this.lastUsage = lastUsage;
+          if (lastUsage) {
+            this.usedToday = new Date(lastUsage).toDateString() === new Date().toDateString();
+          }
+        } catch (e) {
+          console.error(e);
+        } finally {
+          this.loading = false;
+        }
+      }
+    }).mount('#app');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- drop Express server and generate credentials with a simple build step
- reference generated config.js from the Vue UI
- document how to build and open the static site

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_686022c0ae448321a4d3f7d677b2b2ec